### PR TITLE
Sunburst Chart

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -4,6 +4,22 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@arclamp/sunburst-chart": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/@arclamp/sunburst-chart/-/sunburst-chart-1.4.6.tgz",
+      "integrity": "sha512-zpyfjEQtsjkjODfDT7O1uijnTasbBmbYK3nw41spJZRHRMFrGgIWA5PZ4IrDEEZawGY+NPxaYM5dO0sHJJLrvQ==",
+      "requires": {
+        "accessor-fn": "^1.2.2",
+        "d3-hierarchy": "^1.1.8",
+        "d3-interpolate": "^1.3.2",
+        "d3-path": "^1.0.7",
+        "d3-scale": "^3.0.0",
+        "d3-selection": "^1.4.0",
+        "d3-shape": "^1.3.5",
+        "d3-transition": "^1.2.0",
+        "kapsule": "^1.10.1"
+      }
+    },
     "@babel/code-frame": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
@@ -11920,22 +11936,6 @@
         "loader-utils": "^1.0.2",
         "lodash.clonedeep": "^4.5.0",
         "when": "~3.6.x"
-      }
-    },
-    "sunburst-chart": {
-      "version": "1.4.6",
-      "resolved": "https://registry.npmjs.org/sunburst-chart/-/sunburst-chart-1.4.6.tgz",
-      "integrity": "sha512-3CnCQgHu5eNJzoqfKnXOKe0osoKQADOFitijfi8BIa/15+5d+lDlMzj0FXHm4vOnkbl6HMezr2+qlV3whl2JRQ==",
-      "requires": {
-        "accessor-fn": "^1.2.2",
-        "d3-hierarchy": "^1.1.8",
-        "d3-interpolate": "^1.3.2",
-        "d3-path": "^1.0.7",
-        "d3-scale": "^3.0.0",
-        "d3-selection": "^1.4.0",
-        "d3-shape": "^1.3.5",
-        "d3-transition": "^1.2.0",
-        "kapsule": "^1.10.1"
       }
     },
     "supports-color": {

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1801,6 +1801,11 @@
         "negotiator": "0.6.1"
       }
     },
+    "accessor-fn": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/accessor-fn/-/accessor-fn-1.2.2.tgz",
+      "integrity": "sha1-3VLCcUZTiLKXZKt58iIt7dEeSbI="
+    },
     "acorn": {
       "version": "5.7.3",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
@@ -3970,6 +3975,21 @@
       "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.2.3.tgz",
       "integrity": "sha512-x37qq3ChOTLd26hnps36lexMRhNXEtVxZ4B25rL0DVdDsGQIJGB18S7y9XDwlDD6MD/ZBzITCf4JjGMM10TZkw=="
     },
+    "d3-dispatch": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-1.0.5.tgz",
+      "integrity": "sha512-vwKx+lAqB1UuCeklr6Jh1bvC4SZgbSqbkGBLClItFBIYH4vqDJCA7qfoy14lXmJdnBOdxndAMxjCbImJYW7e6g=="
+    },
+    "d3-ease": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-1.0.5.tgz",
+      "integrity": "sha512-Ct1O//ly5y5lFM9YTdu+ygq7LleSgSE4oj7vUt9tPLHUi8VCV7QoizGpdWRWAwCO9LdYzIrQDg97+hGVdsSGPQ=="
+    },
+    "d3-format": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.3.2.tgz",
+      "integrity": "sha512-Z18Dprj96ExragQ0DeGi+SYPQ7pPfRMtUXtsg/ChVIKNBCzjO8XYJvRTC1usblx52lqge56V5ect+frYTQc8WQ=="
+    },
     "d3-geo": {
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-1.7.1.tgz",
@@ -3977,6 +3997,11 @@
       "requires": {
         "d3-array": "1"
       }
+    },
+    "d3-hierarchy": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-1.1.8.tgz",
+      "integrity": "sha512-L+GHMSZNwTpiq4rt9GEsNcpLa4M96lXMR8M/nMG9p5hBE0jy6C+3hWtyZMenPQdwla249iJy7Nx0uKt3n+u9+w=="
     },
     "d3-interpolate": {
       "version": "1.3.2",
@@ -3986,6 +4011,23 @@
         "d3-color": "1"
       }
     },
+    "d3-path": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.7.tgz",
+      "integrity": "sha512-q0cW1RpvA5c5ma2rch62mX8AYaiLX0+bdaSM2wxSU9tXjU4DNvkx9qiUvjkuWCj3p22UO/hlPivujqMiR9PDzA=="
+    },
+    "d3-scale": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-3.0.0.tgz",
+      "integrity": "sha512-ktic5HBFlAZj2CN8CCl/p/JyY8bMQluN7+fA6ICE6yyoMOnSQAZ1Bb8/5LcNpNKMBMJge+5Vv4pWJhARYlQYFw==",
+      "requires": {
+        "d3-array": "^1.2.0 || 2",
+        "d3-format": "1",
+        "d3-interpolate": "1",
+        "d3-time": "1",
+        "d3-time-format": "2"
+      }
+    },
     "d3-scale-chromatic": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-1.3.3.tgz",
@@ -3993,6 +4035,50 @@
       "requires": {
         "d3-color": "1",
         "d3-interpolate": "1"
+      }
+    },
+    "d3-selection": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-1.4.0.tgz",
+      "integrity": "sha512-EYVwBxQGEjLCKF2pJ4+yrErskDnz5v403qvAid96cNdCMr8rmCYfY5RGzWz24mdIbxmDf6/4EAH+K9xperD5jg=="
+    },
+    "d3-shape": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.5.tgz",
+      "integrity": "sha512-VKazVR3phgD+MUCldapHD7P9kcrvPcexeX/PkMJmkUov4JM8IxsSg1DvbYoYich9AtdTsa5nNk2++ImPiDiSxg==",
+      "requires": {
+        "d3-path": "1"
+      }
+    },
+    "d3-time": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-1.0.11.tgz",
+      "integrity": "sha512-Z3wpvhPLW4vEScGeIMUckDW7+3hWKOQfAWg/U7PlWBnQmeKQ00gCUsTtWSYulrKNA7ta8hJ+xXc6MHrMuITwEw=="
+    },
+    "d3-time-format": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.1.3.tgz",
+      "integrity": "sha512-6k0a2rZryzGm5Ihx+aFMuO1GgelgIz+7HhB4PH4OEndD5q2zGn1mDfRdNrulspOfR6JXkb2sThhDK41CSK85QA==",
+      "requires": {
+        "d3-time": "1"
+      }
+    },
+    "d3-timer": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-1.0.9.tgz",
+      "integrity": "sha512-rT34J5HnQUHhcLvhSB9GjCkN0Ddd5Y8nCwDBG2u6wQEeYxT/Lf51fTFFkldeib/sE/J0clIe0pnCfs6g/lRbyg=="
+    },
+    "d3-transition": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-1.2.0.tgz",
+      "integrity": "sha512-VJ7cmX/FPIPJYuaL2r1o1EMHLttvoIuZhhuAlRoOxDzogV8iQS6jYulDm3xEU3TqL80IZIhI551/ebmCMrkvhw==",
+      "requires": {
+        "d3-color": "1",
+        "d3-dispatch": "1",
+        "d3-ease": "1",
+        "d3-interpolate": "1",
+        "d3-selection": "^1.1.0",
+        "d3-timer": "1"
       }
     },
     "dashdash": {
@@ -7514,6 +7600,14 @@
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
           "optional": true
         }
+      }
+    },
+    "kapsule": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/kapsule/-/kapsule-1.10.1.tgz",
+      "integrity": "sha512-Cprn3DhiFMBviPupeh6AGZzvdskJ4aLCEUwGu8/FBKVy++vwwvsVDS4Q5Bm2q+zwrLCC9eaacMAkQ1BvkbAi3A==",
+      "requires": {
+        "debounce": "^1.2.0"
       }
     },
     "killable": {
@@ -11826,6 +11920,22 @@
         "loader-utils": "^1.0.2",
         "lodash.clonedeep": "^4.5.0",
         "when": "~3.6.x"
+      }
+    },
+    "sunburst-chart": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/sunburst-chart/-/sunburst-chart-1.4.6.tgz",
+      "integrity": "sha512-3CnCQgHu5eNJzoqfKnXOKe0osoKQADOFitijfi8BIa/15+5d+lDlMzj0FXHm4vOnkbl6HMezr2+qlV3whl2JRQ==",
+      "requires": {
+        "accessor-fn": "^1.2.2",
+        "d3-hierarchy": "^1.1.8",
+        "d3-interpolate": "^1.3.2",
+        "d3-path": "^1.0.7",
+        "d3-scale": "^3.0.0",
+        "d3-selection": "^1.4.0",
+        "d3-shape": "^1.3.5",
+        "d3-transition": "^1.2.0",
+        "kapsule": "^1.10.1"
       }
     },
     "supports-color": {

--- a/client/package.json
+++ b/client/package.json
@@ -14,6 +14,7 @@
     "resonantgeo": "git+ssh://git@kwgitlab.kitware.com:open-geoscience/resonantgeo.git",
     "stylus": "^0.54.5",
     "stylus-loader": "^3.0.2",
+    "sunburst-chart": "^1.4.6",
     "vue": "^2.6.8",
     "vue-async-computed": "^3.5.1",
     "vue-google-charts": "^0.3.2",

--- a/client/package.json
+++ b/client/package.json
@@ -8,13 +8,13 @@
     "lint": "vue-cli-service lint"
   },
   "dependencies": {
+    "@arclamp/sunburst-chart": "^1.4.6",
     "@girder/components": "git+https://github.com/girder/girder_web_components.git",
     "d3-scale-chromatic": "^1.3.3",
     "papaparse": "^5.0.0",
     "resonantgeo": "git+ssh://git@kwgitlab.kitware.com:open-geoscience/resonantgeo.git",
     "stylus": "^0.54.5",
     "stylus-loader": "^3.0.2",
-    "sunburst-chart": "^1.4.6",
     "vue": "^2.6.8",
     "vue-async-computed": "^3.5.1",
     "vue-google-charts": "^0.3.2",

--- a/client/package.json
+++ b/client/package.json
@@ -11,6 +11,7 @@
     "@arclamp/sunburst-chart": "^1.4.6",
     "@girder/components": "git+https://github.com/girder/girder_web_components.git",
     "d3-scale-chromatic": "^1.3.3",
+    "lodash.debounce": "^4.0.8",
     "papaparse": "^5.0.0",
     "resonantgeo": "git+ssh://git@kwgitlab.kitware.com:open-geoscience/resonantgeo.git",
     "stylus": "^0.54.5",

--- a/client/src/components/PhylogeneticDistribution.vue
+++ b/client/src/components/PhylogeneticDistribution.vue
@@ -1,6 +1,5 @@
 <script>
 import d3 from "d3";
-import { schemeCategory10 } from "d3-scale-chromatic";
 import { GChart } from "vue-google-charts";
 
 export default {
@@ -12,6 +11,9 @@ export default {
     filteredTablesValues: {
       type: Object,
       required: true
+    },
+    cmap: {
+      required: true
     }
   },
   data() {
@@ -20,7 +22,6 @@ export default {
     };
   },
   computed: {
-    schemeCategory10: () => schemeCategory10,
     alphaDiversivty() {
       return this.filteredTablesValues.table7.reduce(
         (total, values) => values["Alpha Diversity"] + total,
@@ -84,6 +85,19 @@ export default {
           .sort((a, b) => b[1] - a[1])
           .slice(0, 12)
       ];
+    },
+    sortedTopSelectedDomainChartColors() {
+      return this.sortedTopSelectedDomainChartData
+        .slice(1)
+        .map(d => d[0])
+        .map(this.cmap);
+    },
+    gChartOptions() {
+      return {
+        chartArea: { width: "95%", height: "95%" },
+        legend: { alignment: "center" },
+        colors: this.sortedTopSelectedDomainChartColors
+      };
     }
   },
   methods: {
@@ -100,7 +114,7 @@ export default {
     <div class="domain-diversity-container">
       <v-tooltip
         top
-        v-for="({ category, count, scaledCount }, i) in domain"
+        v-for="{ category, count, scaledCount } in domain"
         :key="category"
       >
         <template #activator="data">
@@ -109,7 +123,7 @@ export default {
             :class="{ selected: selectedDomain === category }"
             :style="{
               'flex-grow': scaledCount,
-              'background-color': schemeCategory10[i]
+              'background-color': cmap(category)
             }"
             @mouseenter="selectDomain(category)"
           ></div>
@@ -127,10 +141,7 @@ export default {
           style="height: 100%;"
           type="PieChart"
           :data="sortedTopSelectedDomainChartData"
-          :options="{
-            chartArea: { width: '95%', height: '95%' },
-            legend: { alignment: 'center' }
-          }"
+          :options="gChartOptions"
         />
       </div>
     </div>

--- a/client/src/components/Sunburst.vue
+++ b/client/src/components/Sunburst.vue
@@ -1,0 +1,57 @@
+<script>
+import Sunburst from "sunburst-chart";
+
+export default {
+  name: "Sunburst",
+  props: {
+    filteredTablesValues: {
+      type: Object,
+      required: true
+    }
+  },
+  computed: {
+    treeData() {
+      return {
+        name: "root",
+        children: [
+          {
+            name: "A",
+            value: 3
+          },
+          {
+            name: "B",
+            value: 4
+          }
+        ]
+      };
+    }
+  },
+  watch: {
+    treeData(data) {
+      this.update(data);
+    }
+  },
+  mounted() {
+    this.chart = Sunburst()
+      .width(400)
+      .height(400)
+      .data({
+        name: "all",
+        children: []
+      });
+
+    this.chart(this.$refs.container);
+
+    this.update(this.treeData);
+  },
+  methods: {
+    update(data) {
+      this.chart.data(data);
+    }
+  }
+};
+</script>
+
+<template>
+  <div ref="container" />
+</template>

--- a/client/src/components/Sunburst.vue
+++ b/client/src/components/Sunburst.vue
@@ -1,5 +1,58 @@
 <script>
+import { schemePaired } from "d3-scale-chromatic";
+import { scaleOrdinal } from "d3-scale";
 import Sunburst from "sunburst-chart";
+
+function treeifyTable8(tab) {
+  let tree = {};
+  Object.keys(tab).forEach(key => {
+    const val = tab[key];
+    if (val === 0) {
+      return;
+    }
+
+    const [kingdom, species] = key.split(":");
+    tree[kingdom] = tree[kingdom] || {};
+    tree[kingdom][species] = tree[kingdom][species] || 0;
+
+    tree[kingdom][species] += val;
+  });
+
+  return tree;
+}
+
+function speciesAdd(spec1, spec2) {
+  const spec1Keys = Object.keys(spec1);
+  const spec2Keys = Object.keys(spec2);
+  const species = Array.from(new Set(spec1Keys.concat(spec2Keys)));
+
+  let sum = {};
+  species.forEach(spec => {
+    sum[spec] = (spec1[spec] || 0) + (spec2[spec] || 0);
+  });
+
+  return sum;
+}
+
+function treeAdd(tree1, tree2) {
+  const tree1Keys = Object.keys(tree1);
+  const tree2Keys = Object.keys(tree2);
+  const kingdoms = Array.from(new Set(tree1Keys.concat(tree2Keys)));
+
+  let sum = {};
+  kingdoms.forEach(kingdom => {
+    const kingdom1 = tree1[kingdom] || {};
+    const kingdom2 = tree2[kingdom] || {};
+
+    sum[kingdom] = speciesAdd(kingdom1, kingdom2);
+  });
+
+  return sum;
+}
+
+function treeSum(arr) {
+  return arr.reduce((acc, cur) => treeAdd(acc, cur), {});
+}
 
 export default {
   name: "Sunburst",
@@ -11,6 +64,26 @@ export default {
   },
   computed: {
     treeData() {
+      return this.filteredTablesValues.table8.map(treeifyTable8);
+    },
+    treeDataSum() {
+      return treeSum(this.treeData);
+    },
+    sunburstData() {
+      const data = this.treeDataSum;
+
+      return {
+        name: "all",
+        children: Object.keys(data).map(kingdom => ({
+          name: kingdom,
+          children: Object.keys(data[kingdom]).map(species => ({
+            name: species,
+            value: data[kingdom][species]
+          }))
+        }))
+      };
+    },
+    testData() {
       return {
         name: "root",
         children: [
@@ -27,14 +100,18 @@ export default {
     }
   },
   watch: {
-    treeData(data) {
+    sunburstData(data) {
       this.update(data);
     }
   },
   mounted() {
+    const cmap = scaleOrdinal(schemePaired);
+
     this.chart = Sunburst()
       .width(400)
       .height(400)
+      .tooltipContent(d => `value: ${d.value}`)
+      .color((d, parent) => cmap(parent ? parent.data.name : null))
       .data({
         name: "all",
         children: []
@@ -42,7 +119,7 @@ export default {
 
     this.chart(this.$refs.container);
 
-    this.update(this.treeData);
+    this.update(this.sunburstData);
   },
   methods: {
     update(data) {

--- a/client/src/components/Sunburst.vue
+++ b/client/src/components/Sunburst.vue
@@ -76,7 +76,7 @@ export default {
       const data = this.treeDataSum;
 
       return {
-        name: "all",
+        name: "",
         children: Object.keys(data).map(kingdom => ({
           name: kingdom,
           children: Object.keys(data[kingdom]).map(species => ({
@@ -114,7 +114,7 @@ export default {
       .tooltipContent(d => `value: ${d.value}`)
       .color(d => this.cmap(d.name))
       .data({
-        name: "all",
+        name: "",
         children: []
       });
 

--- a/client/src/components/Sunburst.vue
+++ b/client/src/components/Sunburst.vue
@@ -139,3 +139,13 @@ export default {
 <template>
   <div ref="container" />
 </template>
+
+<style>
+textPath.text-contour {
+  stroke: none !important;
+}
+
+textPath.text-stroke {
+  fill: white !important;
+}
+</style>

--- a/client/src/components/Sunburst.vue
+++ b/client/src/components/Sunburst.vue
@@ -1,5 +1,6 @@
 <script>
 import Sunburst from "@arclamp/sunburst-chart";
+import debounce from "lodash.debounce";
 
 function treeifyTable8(tab) {
   let tree = {};
@@ -102,7 +103,7 @@ export default {
   },
   watch: {
     sunburstData(data) {
-      this.update(data);
+      this.debouncedUpdate(data);
     }
   },
   mounted() {
@@ -124,6 +125,8 @@ export default {
           name: "",
           children: []
         });
+
+      this.debouncedUpdate = _.debounce(this.update.bind(this), 500);
 
       this.chart(this.$el);
     });

--- a/client/src/components/Sunburst.vue
+++ b/client/src/components/Sunburst.vue
@@ -106,27 +106,27 @@ export default {
     }
   },
   mounted() {
-    this.chart = Sunburst()
-      .width(400)
-      .height(400)
-      .tooltipShow(d => d.name !== "")
-      .tooltipTitle(d => {
-        const text = this.chart._tooltipTitle(d);
-        return text
-          .split(" > ")
-          .slice(1)
-          .join(" > ");
-      })
-      .tooltipContent(d => (d.value !== undefined ? `value: ${d.value}` : ""))
-      .color(d => this.cmap(d.name))
-      .data({
-        name: "",
-        children: []
-      });
+    this.$nextTick(() => {
+      this.chart = Sunburst()
+        .width(this.$el.offsetWidth)
+        .height(this.$el.offsetHeight)
+        .tooltipShow(d => d.name !== "")
+        .tooltipTitle(d => {
+          const text = this.chart._tooltipTitle(d);
+          return text
+            .split(" > ")
+            .slice(1)
+            .join(" > ");
+        })
+        .tooltipContent(d => (d.value !== undefined ? `value: ${d.value}` : ""))
+        .color(d => this.cmap(d.name))
+        .data({
+          name: "",
+          children: []
+        });
 
-    this.chart(this.$refs.container);
-
-    this.update(this.sunburstData);
+      this.chart(this.$el);
+    });
   },
   methods: {
     update(data) {
@@ -137,10 +137,14 @@ export default {
 </script>
 
 <template>
-  <div ref="container" />
+  <div class="eco-sunburst" />
 </template>
 
 <style>
+.eco-sunburst {
+  flex: 1;
+}
+
 textPath.text-contour {
   stroke: none !important;
 }

--- a/client/src/components/Sunburst.vue
+++ b/client/src/components/Sunburst.vue
@@ -1,7 +1,5 @@
 <script>
-// import { schemePaired } from "d3-scale-chromatic";
-// import { scaleOrdinal } from "d3-scale";
-import Sunburst from "sunburst-chart";
+import Sunburst from "@arclamp/sunburst-chart";
 
 function treeifyTable8(tab) {
   let tree = {};
@@ -111,7 +109,15 @@ export default {
     this.chart = Sunburst()
       .width(400)
       .height(400)
-      .tooltipContent(d => `value: ${d.value}`)
+      .tooltipShow(d => d.name !== "")
+      .tooltipTitle(d => {
+        const text = this.chart._tooltipTitle(d);
+        return text
+          .split(" > ")
+          .slice(1)
+          .join(" > ");
+      })
+      .tooltipContent(d => (d.value !== undefined ? `value: ${d.value}` : ""))
       .color(d => this.cmap(d.name))
       .data({
         name: "",

--- a/client/src/components/Sunburst.vue
+++ b/client/src/components/Sunburst.vue
@@ -1,6 +1,6 @@
 <script>
-import { schemePaired } from "d3-scale-chromatic";
-import { scaleOrdinal } from "d3-scale";
+// import { schemePaired } from "d3-scale-chromatic";
+// import { scaleOrdinal } from "d3-scale";
 import Sunburst from "sunburst-chart";
 
 function treeifyTable8(tab) {
@@ -60,6 +60,9 @@ export default {
     filteredTablesValues: {
       type: Object,
       required: true
+    },
+    cmap: {
+      required: true
     }
   },
   computed: {
@@ -105,13 +108,11 @@ export default {
     }
   },
   mounted() {
-    const cmap = scaleOrdinal(schemePaired);
-
     this.chart = Sunburst()
       .width(400)
       .height(400)
       .tooltipContent(d => `value: ${d.value}`)
-      .color((d, parent) => cmap(parent ? parent.data.name : null))
+      .color(d => this.cmap(d.name))
       .data({
         name: "all",
         children: []

--- a/client/src/views/Home.vue
+++ b/client/src/views/Home.vue
@@ -7,6 +7,7 @@ import SamplesLocation from "@/components/SamplesLocation";
 import PhylogeneticDistribution from "@/components/PhylogeneticDistribution";
 import FunctionalDiversity from "@/components/FunctionalDiversity";
 import MetagenomePropertiesTable from "@/components/MetagenomePropertiesTable";
+import Sunburst from "@/components/Sunburst";
 import { dataset } from "../util/dataLoader";
 console.log(dataset);
 
@@ -18,7 +19,8 @@ export default {
     SamplesLocation,
     PhylogeneticDistribution,
     FunctionalDiversity,
-    MetagenomePropertiesTable
+    MetagenomePropertiesTable,
+    Sunburst
   },
   data() {
     return {
@@ -219,6 +221,18 @@ export default {
                 /></v-card-text>
               </v-card>
             </v-flex>
+
+            <v-flex>
+              <v-card class="fill-height my-flex">
+                <v-card-title class="cyan darken-1 my-dark">
+                  <h4>Sunburst</h4>
+                </v-card-title>
+                <v-card-text class="white-card-text">
+                  <Sunburst :filteredTablesValues="filteredTablesValues" />
+                </v-card-text>
+              </v-card>
+            </v-flex>
+
             <v-flex>
               <v-card
                 v-if="selectedSamples.length === 0"

--- a/client/src/views/Home.vue
+++ b/client/src/views/Home.vue
@@ -27,7 +27,7 @@ export default {
   data() {
     return {
       selectedSamples: [],
-      cmap: scaleOrdinal(schemeCategory10)
+      sc10: scaleOrdinal(schemeCategory10)
     };
   },
   computed: {
@@ -123,6 +123,15 @@ export default {
         );
         return tables;
       }
+    },
+    cmap() {
+      return v => {
+        if (v === "") {
+          return "#ffffff";
+        }
+
+        return this.sc10(v);
+      };
     }
   },
   methods: {}

--- a/client/src/views/Home.vue
+++ b/client/src/views/Home.vue
@@ -1,5 +1,7 @@
 <script>
 import _ from "lodash";
+import { scaleOrdinal } from "d3-scale";
+import { schemeCategory10 } from "d3-scale-chromatic";
 
 import NavigationBar from "@/components/NavigationBar";
 import SampleList from "@/components/SampleList";
@@ -24,7 +26,8 @@ export default {
   },
   data() {
     return {
-      selectedSamples: []
+      selectedSamples: [],
+      cmap: scaleOrdinal(schemeCategory10)
     };
   },
   computed: {
@@ -218,6 +221,7 @@ export default {
                 <v-card-text class="white-card-text px-3 py-2">
                   <PhylogeneticDistribution
                     :filteredTablesValues="filteredTablesValues"
+                    :cmap="cmap"
                 /></v-card-text>
               </v-card>
             </v-flex>
@@ -228,7 +232,10 @@ export default {
                   <h4>Sunburst</h4>
                 </v-card-title>
                 <v-card-text class="white-card-text">
-                  <Sunburst :filteredTablesValues="filteredTablesValues" />
+                  <Sunburst
+                    :filteredTablesValues="filteredTablesValues"
+                    :cmap="cmap"
+                  />
                 </v-card-text>
               </v-card>
             </v-flex>


### PR DESCRIPTION
This adds a sunburst chart to display the "kingdom"/"species" breakdown in a single view.

This is using a patched version of the sunburst-chart package. Care has been taken to match colors between the existing Google Charts instance and this new sunburst chart.

## UPDATE

Added some new commits:
- white label text, without a halo (@aashish24, please take a look)
- render the chart when data is first selected
- render the chart with the correct dimensions
- debounce chart update when data is changing (avoids rendering problem with inconsistent visual state)

![sunburst2](https://user-images.githubusercontent.com/2903332/60594342-b9c46800-9d72-11e9-8718-825f9effe4fe.png)